### PR TITLE
Binner Update

### DIFF
--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 from scipy.stats import binned_statistic_dd
-import warnings
 
 from deepdrivewe.binners.base import Binner
 
@@ -76,20 +77,29 @@ class MultiRectilinearBinner(Binner):
             expand_binnumbers=True,
         )
 
-        # Clip the bin indices so any index outside of defined bins are moved to nearest defined bin
-        nbins_per_dim = [len(edges)-1 for edges in bin_edges]
+        # Clip the bin indices so any index outside of defined bins are moved
+        # to nearest defined bin
+        nbins_per_dim = [len(edges) - 1 for edges in bin_edges]
 
         for idx, ibid in enumerate(bid):
-            if not np.all(ibid> 0) or not np.all(ibid < len(self.bins[idx])):
-                warnings.warn(f"Simulations with progress coordinates outside the bin boundaries definition of dimension {idx} are automatically placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
+            if not np.all(ibid > 0) or not np.all(ibid < len(self.bins[idx])):
+                warnings.warn(
+                    'Simulations with progress coordinates outside the bin '
+                    f'boundaries definition of dimension {idx} are '
+                    'automatically placed into the nearest terminal bins. '
+                    'Consider modifying your bin boundaries by adding '
+                    "'np.inf' or '-np.inf' on either end of your bin "
+                    'definitions.',
+                    stacklevel=2,
+                )
                 bid[idx] = np.clip(ibid, 1, nbins_per_dim[idx])
 
         # Calculate the bin indices in row-major order
         bin_ids = np.zeros(len(pcoords), dtype=int)
         for idx, ibid in enumerate(bid.T):
-            for idim in range(len(nbins_per_dim)-1):
-                bin_ids[idx] += (ibid[idim] -1)  * nbins_per_dim[idim]
-            bin_ids[idx] += (ibid[-1] - 1)
+            for idim in range(len(nbins_per_dim) - 1):
+                bin_ids[idx] += (ibid[idim] - 1) * nbins_per_dim[idim]
+            bin_ids[idx] += ibid[-1] - 1
 
         # Check that the number of bin indices is the same as the
         # number of simulations

--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -81,6 +81,9 @@ class MultiRectilinearBinner(Binner):
         # to nearest defined bin
         nbins_per_dim = [len(edges) - 1 for edges in bin_edges]
 
+        # If binning a 1D coordinate, a 1D array will be returned.
+        bid = np.atleast_2d(bid)
+
         for idx, ibid in enumerate(bid):
             if not np.all(ibid > 0) or not np.all(ibid < len(self.bins[idx])):
                 warnings.warn(

--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 from scipy.stats import binned_statistic_2d
+import warnings
 
 from deepdrivewe.binners.base import Binner
 
@@ -96,7 +97,7 @@ class MultiRectilinearBinner(Binner):
         """
         # Bin the progress coordinates (make sure the target state
         # boundary is included in the target state bin).
-        _, x_edge, _, bid = binned_statistic_2d(
+        _, x_edge, y_edge, bid = binned_statistic_2d(
             *pcoords.T,
             values=None,
             statistic='count',
@@ -104,9 +105,17 @@ class MultiRectilinearBinner(Binner):
             expand_binnumbers=True,
         )
 
+        # Clip the bin indices so any index outside of defined bins are moved to nearest defined bin 
+        for idx, ibid in enumerate(bid):
+            if not np.all(ibid>= 0) or not np.all(ibid < len(self.bins[idx])):
+                warnings.warn("Simulations with progress coordinates outside the bin boundaries definitions are automatically placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
+
+                bid[0] = np.clip(bid[0], 1, len(x_edge)-1)
+                bid[1] = np.clip(bid[1], 1, len(y_edge)-1)
+
         # Calculate the bin indices in row-major order
         bin_ids = np.array(
-            [(ibid[0] - 1) * (len(x_edge) - 1) + ibid[1] for ibid in bid],
+            [(ibid[0] - 1) * (len(x_edge) - 1) + (ibid[1] - 1) for ibid in bid.T],
         )
 
         # Check that the number of bin indices is the same as the

--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
-from scipy.stats import binned_statistic_2d
+from scipy.stats import binned_statistic_dd
 import warnings
 
 from deepdrivewe.binners.base import Binner
@@ -97,8 +97,8 @@ class MultiRectilinearBinner(Binner):
         """
         # Bin the progress coordinates (make sure the target state
         # boundary is included in the target state bin).
-        _, x_edge, y_edge, bid = binned_statistic_2d(
-            *pcoords.T,
+        _, bin_edges, bid = binned_statistic_dd(
+            np.asarray(pcoords),
             values=None,
             statistic='count',
             bins=self.bins,
@@ -106,17 +106,19 @@ class MultiRectilinearBinner(Binner):
         )
 
         # Clip the bin indices so any index outside of defined bins are moved to nearest defined bin 
+        nbins_per_dim = [len(edges)-1 for edges in bin_edges]
+       
         for idx, ibid in enumerate(bid):
-            if not np.all(ibid>= 0) or not np.all(ibid < len(self.bins[idx])):
-                warnings.warn("Simulations with progress coordinates outside the bin boundaries definitions are automatically placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
-
-                bid[0] = np.clip(bid[0], 1, len(x_edge)-1)
-                bid[1] = np.clip(bid[1], 1, len(y_edge)-1)
+            if not np.all(ibid> 0) or not np.all(ibid < len(self.bins[idx])):
+                warnings.warn(f"Simulations with progress coordinates outside the bin boundaries definition of dimension {idx} are automatically placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
+                bid[idx] = np.clip(ibid, 1, nbins_per_dim[idx])
 
         # Calculate the bin indices in row-major order
-        bin_ids = np.array(
-            [(ibid[0] - 1) * (len(x_edge) - 1) + (ibid[1] - 1) for ibid in bid.T],
-        )
+        bin_ids = np.zeros(len(pcoords), dtype=int)
+        for idx, ibid in enumerate(bid.T):
+            for idim in range(len(nbins_per_dim)-1):
+                bin_ids[idx] += (ibid[idim] -1)  * nbins_per_dim[idim]
+            bin_ids[idx] += (ibid[-1] - 1)
 
         # Check that the number of bin indices is the same as the
         # number of simulations

--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -105,9 +105,9 @@ class MultiRectilinearBinner(Binner):
             expand_binnumbers=True,
         )
 
-        # Clip the bin indices so any index outside of defined bins are moved to nearest defined bin 
+        # Clip the bin indices so any index outside of defined bins are moved to nearest defined bin
         nbins_per_dim = [len(edges)-1 for edges in bin_edges]
-       
+
         for idx, ibid in enumerate(bid):
             if not np.all(ibid> 0) or not np.all(ibid < len(self.bins[idx])):
                 warnings.warn(f"Simulations with progress coordinates outside the bin boundaries definition of dimension {idx} are automatically placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")

--- a/deepdrivewe/binners/rectilinear.py
+++ b/deepdrivewe/binners/rectilinear.py
@@ -93,4 +93,11 @@ class RectilinearBinner(Binner):
         """
         # Bin the progress coordinates (make sure the target state
         # boundary is included in the target state bin).
-        return np.digitize(pcoords[:, self.pcoord_idx], self.bins, right=True)
+        bin_id = np.digitize(pcoords[:, self.pcoord_idx], self.bins) -1
+
+        if not np.all(bin_id >= 0) or not np.all(bin_id < len(self.bins)):
+            warnings.warn("Simulations with progress coordinates outside the bin boundaries definitions are placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
+
+        # This ensures our bin index is >=0 and < len(self.bins)
+        return np.clip(bin_id, 0, len(self.bins)-1)
+

--- a/deepdrivewe/binners/rectilinear.py
+++ b/deepdrivewe/binners/rectilinear.py
@@ -101,4 +101,3 @@ class RectilinearBinner(Binner):
 
         # This ensures our bin index is >=0 and < len(self.bins)
         return np.clip(bin_id, 0, len(self.bins)-1)
-

--- a/deepdrivewe/binners/rectilinear.py
+++ b/deepdrivewe/binners/rectilinear.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import warnings
 
 from deepdrivewe.binners.base import Binner
 
@@ -95,7 +96,7 @@ class RectilinearBinner(Binner):
         # boundary is included in the target state bin).
         bin_id = np.digitize(pcoords[:, self.pcoord_idx], self.bins) -1
 
-        if not np.all(bin_id >= 0) or not np.all(bin_id < len(self.bins)):
+        if not np.all(bin_id > 0) or not np.all(bin_id < len(self.bins)):
             warnings.warn("Simulations with progress coordinates outside the bin boundaries definitions are placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
 
         # This ensures our bin index is >=0 and < len(self.bins)

--- a/deepdrivewe/binners/rectilinear.py
+++ b/deepdrivewe/binners/rectilinear.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
 import warnings
+
+import numpy as np
 
 from deepdrivewe.binners.base import Binner
 
@@ -65,10 +66,17 @@ class RectilinearBinner(Binner):
         """
         # Bin the progress coordinates (make sure the target state
         # boundary is included in the target state bin).
-        bin_id = np.digitize(pcoords[:, self.pcoord_idx], self.bins) -1
+        bin_ids = np.digitize(pcoords[:, self.pcoord_idx], self.bins) - 1
 
-        if not np.all(bin_id > 0) or not np.all(bin_id < len(self.bins)):
-            warnings.warn("Simulations with progress coordinates outside the bin boundaries definitions are placed into the nearest terminal bins. Consider modifying your bin boundaries by adding 'np.inf' or '-np.inf' on either end of your bin definitions.")
+        # Check that the bin indices are within the valid range
+        if not np.all(bin_ids > 0) or not np.all(bin_ids < len(self.bins)):
+            warnings.warn(
+                'Simulations with progress coordinates outside the bin '
+                'boundaries definitions are placed into the nearest terminal '
+                'bins. Consider modifying your bin boundaries by adding '
+                "'np.inf' or '-np.inf' on either end of your bin definitions.",
+                stacklevel=2,
+            )
 
         # This ensures our bin index is >=0 and < len(self.bins)
-        return np.clip(bin_id, 0, len(self.bins)-1)
+        return np.clip(bin_ids, 0, len(self.bins) - 1)

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -11,7 +11,7 @@ class TestRectilinearBinner:
         coords = np.array([-1, 0, 0.5, 1.5, 1.6, 2.0, 2.0, 2.9])[:, None]
 
         assigner = RectilinearBinner(bins=bounds, bin_target_counts = 3, target_state_inds=[None], pcoord_idx=0)
-        
+
         with pytest.warns(UserWarning):
             assert (assigner.assign_bins(coords) == [0, 0, 0, 1, 1, 2, 2, 2]).all()
 
@@ -41,5 +41,3 @@ class TestRectilinearBinner:
 
         with pytest.warns(UserWarning):
             assert (assigner.assign_bins(coords) == [0, 0, 5, 10, 10, 15, 7, 8]).all()
-
-

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -6,16 +6,16 @@ import numpy as np
 from deepdrivewe.binners import RectilinearBinner, MultiRectilinearBinner
 
 class TestRectilinearBinner:
-    def test1dAssign(self):
+    def test1dAssign(self) -> None:
         bounds = [0.0, 1.0, 2.0, 3.0]
         coords = np.array([-1, 0, 0.5, 1.5, 1.6, 2.0, 2.0, 2.9])[:, None]
 
-        assigner = RectilinearBinner(bins=bounds, bin_target_counts = 3, target_state_inds=[None], pcoord_idx=0)
+        assigner = RectilinearBinner(bins=bounds, bin_target_counts=3, target_state_inds=[None], pcoord_idx=0)
 
         with pytest.warns(UserWarning):
             assert (assigner.assign_bins(coords) == [0, 0, 0, 1, 1, 2, 2, 2]).all()
 
-    def test2dAssign(self):
+    def test2dAssign(self) -> None:
         boundaries = [(-1, -0.5, 0, 0.5, 1), (-1, -0.5, 0, 0.5, 1)]
         coords = np.array([(-2, -2), (-0.75, -0.75), (-0.25, -0.25), (0, 0), (0.25, 0.25), (0.75, 0.75), (-0.25, 0.75), (0.25, -0.75)])
 

--- a/tests/test_binner.py
+++ b/tests/test_binner.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+import numpy as np
+
+from deepdrivewe.binners import RectilinearBinner, MultiRectilinearBinner
+
+class TestRectilinearBinner:
+    def test1dAssign(self):
+        bounds = [0.0, 1.0, 2.0, 3.0]
+        coords = np.array([0, 0.5, 1.5, 1.6, 2.0, 2.0, 2.9])[:, None]
+
+        assigner = RectilinearBinner(bins=bounds, bin_target_counts = 3, target_state_inds=[None], pcoord_idx=0)
+        assert (assigner.assign_bins(coords) == [0, 0, 1, 1, 2, 2, 2]).all()
+
+    def test2dAssign(self):
+        boundaries = [(-1, -0.5, 0, 0.5, 1), (-1, -0.5, 0, 0.5, 1)]
+        coords = np.array([(-0.75, -0.75), (-0.25, -0.25), (0, 0), (0.25, 0.25), (0.75, 0.75), (-0.25, 0.75), (0.25, -0.75)])
+        assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
+
+        """bin structure: [(a,b), (c,d)] => x in [a,b), y in [c, d)
+        0:[(-1, -0.5), (-1, -0.5)]
+        1:[(-1, -0.5), (-0.5, 0)]
+        2:[(-1, -0.5), (0, 0.5)]
+        3:[(-1, -0.5), (0.5, 1)]
+        4:[(-0.5, 0), (-1, -0.5)]
+        5:[(-0.5, 0), (-0.5, 0)]
+        6:[(-0.5, 0), (0, 0.5)]
+        7:[(-0.5, 0), (0.5, 1)]
+        8:[(0, 0.5), (-1, -0.5)]
+        9:[(0, 0.5), (-0.5, 0)]
+        10:[(0, 0.5), (0, 0.5)]
+        11:[(0, 0.5), (0.5, 1)]
+        12:[(0.5, 1), (-1, -0.5)]
+        13:[(0.5, 1), (-0.5, 0)]
+        14:[(0.5, 1), (0, 0.5)]
+        15:[(0.5, 1), (0.5, 1)]"""
+
+        assert (assigner.assign_bins(coords) == [0, 5, 10, 10, 15, 7, 8]).all()
+
+

--- a/tests/test_binner.py
+++ b/tests/test_binner.py
@@ -8,14 +8,17 @@ from deepdrivewe.binners import RectilinearBinner, MultiRectilinearBinner
 class TestRectilinearBinner:
     def test1dAssign(self):
         bounds = [0.0, 1.0, 2.0, 3.0]
-        coords = np.array([0, 0.5, 1.5, 1.6, 2.0, 2.0, 2.9])[:, None]
+        coords = np.array([-1, 0, 0.5, 1.5, 1.6, 2.0, 2.0, 2.9])[:, None]
 
         assigner = RectilinearBinner(bins=bounds, bin_target_counts = 3, target_state_inds=[None], pcoord_idx=0)
-        assert (assigner.assign_bins(coords) == [0, 0, 1, 1, 2, 2, 2]).all()
+        
+        with pytest.warns(UserWarning):
+            assert (assigner.assign_bins(coords) == [0, 0, 0, 1, 1, 2, 2, 2]).all()
 
     def test2dAssign(self):
         boundaries = [(-1, -0.5, 0, 0.5, 1), (-1, -0.5, 0, 0.5, 1)]
-        coords = np.array([(-0.75, -0.75), (-0.25, -0.25), (0, 0), (0.25, 0.25), (0.75, 0.75), (-0.25, 0.75), (0.25, -0.75)])
+        coords = np.array([(-2, -2), (-0.75, -0.75), (-0.25, -0.25), (0, 0), (0.25, 0.25), (0.75, 0.75), (-0.25, 0.75), (0.25, -0.75)])
+
         assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
 
         """bin structure: [(a,b), (c,d)] => x in [a,b), y in [c, d)
@@ -36,6 +39,7 @@ class TestRectilinearBinner:
         14:[(0.5, 1), (0, 0.5)]
         15:[(0.5, 1), (0.5, 1)]"""
 
-        assert (assigner.assign_bins(coords) == [0, 5, 10, 10, 15, 7, 8]).all()
+        with pytest.warns(UserWarning):
+            assert (assigner.assign_bins(coords) == [0, 0, 5, 10, 10, 15, 7, 8]).all()
 
 


### PR DESCRIPTION
#34 
Fixes some errors with the `RectilinearBinner` (changed inclusive behavior to be more pythonic-- `[a,b)`, indexing issue with `np.digitize` ) and updated the `MultiRectilinearBinner` to take in 2D+ pcoords. We could eventually deprecate/remove the `RectilinearBinner` if we want, since Multi does it all.