### PR TITLE
Claude/ecstatic mcnulty: feat: Implement decentralized Academy agent topology (TrainingAgent + InferenceAgent)

### DIFF
--- a/deepdrivewe/academy_agents/config.py
+++ b/deepdrivewe/academy_agents/config.py
@@ -12,6 +12,94 @@ from deepdrivewe import BaseModel
 from deepdrivewe.simulation.openmm import OpenMMConfig
 
 
+class TrainingAgentConfig(BaseModel):
+    """Configuration for the TrainingAgent.
+
+    The TrainingAgent runs on a GPU node and trains the CVAE model
+    on simulation data as it arrives (streaming / online training).
+    The model stays warm in GPU memory across iterations.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory to store CVAE model checkpoints and training logs.
+    pretrained_model_path : Path | None
+        Path to a pretrained CVAE checkpoint to load on startup.
+        If None, the model is initialized from scratch.
+    train_frequency : int
+        Number of SimResult objects to accumulate before triggering
+        a training step. Default is 1 (train on every result).
+    cvae_config : dict[str, Any] | None
+        Dictionary of ``ConvolutionalVAEConfig`` fields. Passed through
+        to the CVAE constructor. If None, default CVAE settings are used.
+    """
+
+    output_dir: Path = Field(
+        description='Directory to store CVAE model checkpoints and logs.',
+    )
+    pretrained_model_path: Path | None = Field(
+        default=None,
+        description='Path to a pretrained CVAE checkpoint to load on startup.',
+    )
+    train_frequency: int = Field(
+        default=1,
+        ge=1,
+        description='Number of SimResults to accumulate before training.',
+    )
+    cvae_config: dict[str, Any] | None = Field(
+        default=None,
+        description='ConvolutionalVAEConfig fields (dict). '
+        'None uses CVAE defaults.',
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Create output directory after initialization."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+class InferenceAgentConfig(BaseModel):
+    """Configuration for the InferenceAgent.
+
+    The InferenceAgent runs on a GPU node and drives the weighted ensemble
+    iteration loop. It collects simulation results, runs CVAE inference
+    (latent projection), applies WE resampling, saves checkpoints, and
+    dispatches the next iteration of simulations.
+
+    A pretrained model should be provided so that the inference agent is
+    ready from iteration 1 without waiting for the training agent to
+    complete its first training step.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory to store inference outputs.
+    pretrained_model_path : Path | None
+        Path to a pretrained CVAE checkpoint to load on startup.
+        Strongly recommended so that inference is available at iteration 1.
+    cvae_config : dict[str, Any] | None
+        Dictionary of ``ConvolutionalVAEConfig`` fields used during the
+        inference (predict) step. If None, default CVAE settings are used.
+    """
+
+    output_dir: Path = Field(
+        description='Directory to store inference outputs.',
+    )
+    pretrained_model_path: Path | None = Field(
+        default=None,
+        description='Path to a pretrained CVAE checkpoint to load on startup. '
+        'Strongly recommended for warm startup.',
+    )
+    cvae_config: dict[str, Any] | None = Field(
+        default=None,
+        description='ConvolutionalVAEConfig fields (dict). '
+        'None uses CVAE defaults.',
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Create output directory after initialization."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+
 class SimulationPoolConfig(BaseModel):
     """Configuration for the simulation pool agent.
 
@@ -116,10 +204,19 @@ class AcademyWorkflowConfig(BaseModel):
         Number of weighted ensemble iterations to run.
     checkpoint_interval : int
         Save ensemble checkpoint every N iterations.
+    num_simulations : int
+        Number of parallel SimulationAgents (one per trajectory).
     simulation_pool_config : SimulationPoolConfig
-        Configuration for the simulation pool.
-    analysis_pool_config : AnalysisPoolConfig
-        Configuration for the analysis pool (Phase 3).
+        Configuration for each SimulationAgent.
+    training_agent_config : TrainingAgentConfig | None
+        Configuration for the TrainingAgent. If None, training is disabled
+        and no CVAE model updates will occur.
+    inference_agent_config : InferenceAgentConfig | None
+        Configuration for the InferenceAgent. If None, the legacy
+        OrchestratorAgent-based iteration loop is used instead.
+    analysis_pool_config : AnalysisPoolConfig | None
+        Configuration for the legacy analysis pool agent (Phase 3).
+        Only used when inference_agent_config is None.
     """
 
     output_dir: Path = Field(
@@ -134,12 +231,27 @@ class AcademyWorkflowConfig(BaseModel):
         ge=1,
         description='Save ensemble checkpoint every N iterations.',
     )
+    num_simulations: int = Field(
+        default=4,
+        ge=1,
+        description='Number of parallel SimulationAgents to launch.',
+    )
     simulation_pool_config: SimulationPoolConfig = Field(
-        description='Configuration for the simulation pool.',
+        description='Configuration for each SimulationAgent.',
+    )
+    training_agent_config: TrainingAgentConfig | None = Field(
+        default=None,
+        description='Configuration for the TrainingAgent. '
+        'If None, CVAE training is disabled.',
+    )
+    inference_agent_config: InferenceAgentConfig | None = Field(
+        default=None,
+        description='Configuration for the InferenceAgent. '
+        'If None, the legacy OrchestratorAgent loop is used.',
     )
     analysis_pool_config: AnalysisPoolConfig | None = Field(
         default=None,
-        description='Configuration for the analysis pool (Phase 3).',
+        description='Configuration for the legacy analysis pool (Phase 3).',
     )
 
     def model_post_init(self, __context: Any) -> None:

--- a/deepdrivewe/academy_agents/inference.py
+++ b/deepdrivewe/academy_agents/inference.py
@@ -1,0 +1,403 @@
+"""Inference agent for weighted ensemble resampling and next-iteration dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from academy.agent import action
+from academy.agent import loop
+from academy.handle import Handle
+
+from deepdrivewe.api import SimMetadata
+from deepdrivewe.api import SimResult
+from deepdrivewe.api import TrainResult
+from deepdrivewe.api import WeightedEnsemble
+from deepdrivewe.academy_agents.base import AcademyAgent
+from deepdrivewe.binners.base import Binner
+from deepdrivewe.checkpoint import EnsembleCheckpointer
+from deepdrivewe.recyclers.base import Recycler
+from deepdrivewe.resamplers.base import Resampler
+
+if TYPE_CHECKING:
+    from deepdrivewe.academy_agents.simulation import SimulationAgent
+
+
+class InferenceAgentConfig:
+    """Configuration for the InferenceAgent.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory to store inference outputs and model state.
+    pretrained_model_path : Path | None
+        Path to a pretrained CVAE model checkpoint to load on startup.
+        Having a pretrained model ensures the inference agent is ready
+        immediately at iteration 1 without waiting for the training agent.
+    cvae_config : ConvolutionalVAEConfig | None
+        Configuration for the CVAE model used during inference (predict step).
+        If None, default settings are used.
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        pretrained_model_path: Path | None = None,
+        cvae_config: object | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.pretrained_model_path = pretrained_model_path
+        self.cvae_config = cvae_config
+
+
+class InferenceAgent(AcademyAgent):
+    """Agent that runs inference and drives the weighted ensemble iteration loop.
+
+    This agent is the workflow coordinator in the decentralized Academy
+    architecture. It:
+
+    1. Collects SimResult objects from all N SimulationAgents
+    2. Receives updated model weights from the TrainingAgent
+    3. Runs CVAE inference (latent space projection) on collected data
+    4. Applies WE resampling (binning, recycling, splitting/merging)
+    5. Saves the ensemble checkpoint
+    6. Dispatches the next iteration's SimMetadata to each SimulationAgent
+    7. Signals shutdown when ``max_iterations`` is reached
+
+    This mirrors the InferenceAgent from the minimal_pattern example
+    (https://github.com/braceal/deepdrivewe-academy), extended with real
+    CVAE inference and weighted ensemble resampling logic.
+
+    The model stays warm in GPU memory across iterations because it is loaded
+    in ``agent_on_startup()`` and kept as an instance attribute for the
+    lifetime of the agent process.
+
+    Attributes
+    ----------
+    num_simulations : int
+        Number of SimulationAgents to collect results from per iteration.
+    max_iterations : int
+        Total number of WE iterations to run before shutting down.
+    simulation_handles : list[Handle[SimulationAgent]]
+        Handles to each SimulationAgent (used to dispatch next iteration).
+    config : InferenceAgentConfig
+        Configuration for the inference agent.
+    binner : Binner
+        WE binner for assigning simulations to bins.
+    resampler : Resampler
+        WE resampler for splitting/merging trajectories.
+    recycler : Recycler
+        WE recycler for handling terminal states.
+    ensemble : WeightedEnsemble
+        The current weighted ensemble state.
+    checkpointer : EnsembleCheckpointer
+        Checkpointer for saving ensemble state to disk after each iteration.
+    """
+
+    # Private state (not serialized, initialized in agent_on_startup)
+    __logger: logging.Logger
+    __batch: list[SimResult]
+    __batch_ready: asyncio.Event
+    __model_lock: asyncio.Lock
+
+    def __init__(
+        self,
+        num_simulations: int,
+        max_iterations: int,
+        simulation_handles: list[Handle[SimulationAgent]],
+        config: InferenceAgentConfig,
+        binner: Binner,
+        resampler: Resampler,
+        recycler: Recycler,
+        ensemble: WeightedEnsemble,
+        checkpointer: EnsembleCheckpointer,
+    ) -> None:
+        """Initialize the inference agent.
+
+        Parameters
+        ----------
+        num_simulations : int
+            Number of simulation agents (batch size per iteration).
+        max_iterations : int
+            Total WE iterations to run.
+        simulation_handles : list[Handle[SimulationAgent]]
+            Handles for dispatching next-iteration work to each SimulationAgent.
+        config : InferenceAgentConfig
+            Configuration for the inference agent.
+        binner : Binner
+            WE binner.
+        resampler : Resampler
+            WE resampler.
+        recycler : Recycler
+            WE recycler.
+        ensemble : WeightedEnsemble
+            Initial weighted ensemble state (may be loaded from checkpoint).
+        checkpointer : EnsembleCheckpointer
+            Checkpointer to save ensemble state after each iteration.
+        """
+        super().__init__()
+        self.num_simulations = num_simulations
+        self.max_iterations = max_iterations
+        self.simulation_handles = simulation_handles
+        self.config = config
+        self.binner = binner
+        self.resampler = resampler
+        self.recycler = recycler
+        self.ensemble = ensemble
+        self.checkpointer = checkpointer
+
+    async def agent_on_startup(self) -> None:
+        """Initialize state and load the pretrained CVAE model onto GPU.
+
+        All stateful initialization happens here so it runs on the correct
+        worker process (i.e., the GPU node where this agent is placed by
+        the ParslPoolExecutor). This ensures the model is warm in GPU memory
+        before the first iteration starts.
+        """
+        self.__logger = logging.getLogger(self.__class__.__name__)  # type: ignore[misc]
+        self.__batch = []
+        self.__batch_ready = asyncio.Event()
+        self.__model_lock = asyncio.Lock()
+
+        # Ensure output directory exists
+        self.config.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load the CVAE model for inference (lazy import for HPC compatibility)
+        try:
+            from deepdrivewe.ai.cvae import ConvolutionalVAE
+            from deepdrivewe.ai.cvae import ConvolutionalVAEConfig
+
+            cvae_config = (
+                self.config.cvae_config
+                if self.config.cvae_config is not None
+                else ConvolutionalVAEConfig()
+            )
+
+            self.__model = ConvolutionalVAE(  # type: ignore[misc]
+                config=cvae_config,
+                checkpoint_path=self.config.pretrained_model_path,
+            )
+
+            self.__logger.info(
+                'CVAE inference model loaded'
+                + (
+                    f' from {self.config.pretrained_model_path}'
+                    if self.config.pretrained_model_path
+                    else ' (initialized from scratch)'
+                ),
+            )
+        except ImportError as e:
+            self.__logger.warning(
+                f'Could not import CVAE model dependencies: {e}. '
+                'Running in mock mode (no latent projection during inference).',
+            )
+            self.__model = None  # type: ignore[misc]
+
+        self.__logger.info(
+            f'InferenceAgent started. Will run {self.max_iterations} iterations '
+            f'with {self.num_simulations} simulation(s) per iteration.',
+        )
+
+    @action
+    async def receive_simulation_data(self, result: SimResult) -> None:
+        """Receive one SimResult and buffer it for the current batch.
+
+        Called by each SimulationAgent after completing its run. When
+        ``num_simulations`` results have been received, the ``__batch_ready``
+        event is set to trigger the inference loop.
+
+        Parameters
+        ----------
+        result : SimResult
+            Completed simulation result (trajectory data + metadata).
+        """
+        self.__logger.info(
+            f'Received result for sim {result.metadata.simulation_id} '
+            f'iteration {result.metadata.iteration_id}. '
+            f'Batch: {len(self.__batch) + 1}/{self.num_simulations}',
+        )
+        self.__batch.append(result)
+
+        # Signal the infer loop when all results are collected
+        if len(self.__batch) >= self.num_simulations:
+            self.__batch_ready.set()
+
+    @action
+    async def receive_model_weights(self, train_result: TrainResult) -> None:
+        """Receive updated model weights from the TrainingAgent.
+
+        Updates the CVAE model weights used for latent space inference.
+        An async lock guards model updates to avoid races with the infer loop.
+
+        Parameters
+        ----------
+        train_result : TrainResult
+            Result from a training step, containing the checkpoint path.
+        """
+        self.__logger.info(
+            f'Received updated model weights: {train_result.checkpoint_path}',
+        )
+        async with self.__model_lock:
+            if self.__model is not None:  # type: ignore[misc]
+                try:
+                    await asyncio.to_thread(
+                        self.__model.update_model,  # type: ignore[misc]
+                        train_result.checkpoint_path,
+                    )
+                    self.__logger.info('Model weights updated successfully')
+                except Exception as e:
+                    self._log_error('receive_model_weights', e)
+
+    @loop
+    async def infer(self, shutdown: asyncio.Event) -> None:
+        """Wait for a full batch then run inference and advance the WE iteration.
+
+        This is the main driver loop of the entire workflow. For each iteration:
+        1. Waits until all N simulation results are collected
+        2. Runs CVAE latent projection on contact maps (under model lock)
+        3. Applies WE resampling (bin → recycle → split/merge)
+        4. Saves the ensemble checkpoint
+        5. Dispatches the next iteration's SimMetadata to each SimulationAgent
+        6. Shuts down when max_iterations is reached
+
+        Parameters
+        ----------
+        shutdown : asyncio.Event
+            Event set by the Academy runtime when the agent should stop.
+        """
+        self.__logger.info('Inference loop started')
+
+        while not shutdown.is_set():
+            # Wait until all simulation results are collected
+            try:
+                await asyncio.wait_for(
+                    self.__batch_ready.wait(),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                # Check shutdown periodically
+                continue
+
+            self.__batch_ready.clear()
+
+            # Grab the current batch and reset for next iteration
+            batch = self.__batch
+            self.__batch = []
+
+            current_iteration = self.ensemble.iteration
+            self.__logger.info(
+                f'Running inference on {len(batch)} results for '
+                f'iteration {current_iteration}',
+            )
+
+            try:
+                # Step 1: Run CVAE latent projection (updates auxdata in-place)
+                async with self.__model_lock:
+                    if self.__model is not None:  # type: ignore[misc]
+                        await asyncio.to_thread(
+                            self._project_to_latent,
+                            batch,
+                        )
+
+                # Step 2: Extract SimMetadata from results (with pcoords populated)
+                cur_sims = [result.metadata for result in batch]
+
+                # Step 3: Apply WE resampling pipeline
+                cur_sims_out, next_sims, iteration_metadata = (
+                    await asyncio.to_thread(
+                        self.resampler.run,
+                        cur_sims,
+                        self.binner,
+                        self.recycler,
+                    )
+                )
+
+                # Step 4: Advance ensemble state
+                self.ensemble.advance_iteration(
+                    cur_sims=cur_sims_out,
+                    next_sims=next_sims,
+                    metadata=iteration_metadata,
+                )
+
+                # Step 5: Save checkpoint
+                await asyncio.to_thread(self.checkpointer.save, self.ensemble)
+
+                self.__logger.info(
+                    f'Iteration {current_iteration} complete. '
+                    f'Next iteration: {len(next_sims)} simulations.',
+                )
+
+            except Exception as e:
+                self._log_error('infer', e)
+                # Do not shut down on error — log and continue waiting
+                # for the next batch (simulations may retry)
+                continue
+
+            # Check if we have reached the maximum number of iterations
+            if current_iteration >= self.max_iterations:
+                self.__logger.info(
+                    f'Reached max iterations ({self.max_iterations}), '
+                    'shutting down.',
+                )
+                shutdown.set()
+                return
+
+            # Step 6: Dispatch the next iteration of simulations
+            # next_sims may have more or fewer entries than simulation_handles
+            # (due to splitting/merging). We cycle through handles if needed.
+            self.__logger.info(
+                f'Kicking off iteration {current_iteration + 1} '
+                f'with {len(next_sims)} simulations.',
+            )
+
+            dispatch_tasks = []
+            for idx, sim_meta in enumerate(next_sims):
+                # Round-robin across available simulation handles
+                handle = self.simulation_handles[idx % len(self.simulation_handles)]
+                dispatch_tasks.append(handle.simulate(sim_meta))
+
+            # Dispatch all simulations concurrently
+            await asyncio.gather(*dispatch_tasks)
+
+        self.__logger.info('Inference loop exited')
+
+    def _project_to_latent(self, batch: list[SimResult]) -> None:
+        """Run CVAE latent projection and store embeddings in SimResult auxdata.
+
+        This is a synchronous method executed in a thread (via asyncio.to_thread)
+        so that GPU computation does not block the event loop.
+
+        Parameters
+        ----------
+        batch : list[SimResult]
+            Batch of simulation results. Contact maps are read from
+            ``result.data['contact_maps']`` and latent embeddings are
+            stored back into ``result.metadata.auxdata['latent_embeddings']``.
+        """
+        import numpy as np
+
+        for result in batch:
+            contact_maps = result.data.get('contact_maps')
+
+            if contact_maps is None or len(contact_maps) == 0:
+                self.__logger.debug(
+                    f'No contact maps for sim {result.metadata.simulation_id}',
+                )
+                continue
+
+            # Ensure correct dtype / shape for CVAE
+            x = np.array(contact_maps)
+
+            # Run prediction (n_frames, latent_dim)
+            try:
+                embeddings = self.__model.predict(x)  # type: ignore[misc]
+                result.metadata.auxdata['latent_embeddings'] = (
+                    embeddings.tolist()
+                )
+            except Exception as e:
+                self.__logger.warning(
+                    f'CVAE prediction failed for sim '
+                    f'{result.metadata.simulation_id}: {e}',
+                )

--- a/deepdrivewe/academy_agents/simulation.py
+++ b/deepdrivewe/academy_agents/simulation.py
@@ -3,52 +3,153 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import shutil
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
+
+import numpy as np
 
 from academy.agent import action
 from academy.agent import loop
 from academy.handle import Handle
 
 from deepdrivewe import SimMetadata
+from deepdrivewe.api import SimResult
 from deepdrivewe.academy_agents.base import AcademyAgent
 from deepdrivewe.academy_agents.config import SimulationPoolConfig
 from deepdrivewe.simulation.openmm import OpenMMSimulation
+
+if TYPE_CHECKING:
+    from deepdrivewe.academy_agents.training import TrainingAgent
+    from deepdrivewe.academy_agents.inference import InferenceAgent
 
 
 class SimulationAgent(AcademyAgent):
     """Agent that executes individual MD simulations.
 
-    This agent runs OpenMM simulations and returns trajectory data.
-    It maintains a queue of simulation tasks and processes them
-    sequentially in its await_task loop.
+    In the decentralized Academy architecture, each SimulationAgent is its
+    own actor. It receives ``SimMetadata`` via the ``simulate`` action,
+    runs the OpenMM simulation, and streams the ``SimResult`` directly to
+    both the TrainingAgent and the InferenceAgent — no central orchestrator
+    is involved.
+
+    This mirrors the SimulationAgent from the minimal_pattern example
+    (https://github.com/braceal/deepdrivewe-academy), extended with real
+    OpenMM simulation logic.
 
     Attributes
     ----------
     config : SimulationPoolConfig
-        Configuration for simulations.
-    current_task : dict[str, Any] | None
-        Currently executing simulation task.
-    is_busy : bool
-        Whether the agent is currently running a simulation.
+        Configuration for simulations (output dir, OpenMM settings, etc.).
+    train_handle : Handle[TrainingAgent] | None
+        Handle to the TrainingAgent. When set, the SimResult is streamed
+        directly after each simulation completes.
+    inference_handle : Handle[InferenceAgent] | None
+        Handle to the InferenceAgent. When set, the SimResult is sent
+        directly after each simulation completes.
     """
 
-    def __init__(self, config: SimulationPoolConfig) -> None:
+    # Private logger (not serialized)
+    __logger: logging.Logger
+
+    def __init__(
+        self,
+        config: SimulationPoolConfig,
+        train_handle: Handle[TrainingAgent] | None = None,
+        inference_handle: Handle[InferenceAgent] | None = None,
+    ) -> None:
         """Initialize the simulation agent.
 
         Parameters
         ----------
         config : SimulationPoolConfig
             Configuration for simulations.
+        train_handle : Handle[TrainingAgent] | None
+            Handle to the TrainingAgent for streaming simulation results.
+            If None, results are not forwarded (pool-based mode).
+        inference_handle : Handle[InferenceAgent] | None
+            Handle to the InferenceAgent for streaming simulation results.
+            If None, results are not forwarded (pool-based mode).
         """
         super().__init__()
         self.config = config
+        self.train_handle = train_handle
+        self.inference_handle = inference_handle
+
+        # Legacy pool-based state (kept for backwards compatibility)
         self.current_task: dict[str, Any] | None = None
         self.is_busy = False
         self._task_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._shutdown_event = asyncio.Event()
+
+    async def agent_on_startup(self) -> None:
+        """Initialize the agent logger."""
+        self.__logger = logging.getLogger(self.__class__.__name__)  # type: ignore[misc]
+        self.__logger.info('SimulationAgent started')
+
+    @action
+    async def simulate(self, sim_metadata: SimMetadata) -> None:
+        """Run a simulation and send the result to the TrainingAgent and InferenceAgent.
+
+        This is the primary entry point in the decentralized Academy pattern.
+        It is called by the InferenceAgent at the start of each iteration
+        (or by ``main()`` to kick off iteration 1). After the simulation
+        completes, the ``SimResult`` is forwarded simultaneously to both
+        the TrainingAgent (for online model training) and the InferenceAgent
+        (for batch collection and WE resampling).
+
+        This matches the ``simulate`` action in the minimal_pattern example.
+
+        Parameters
+        ----------
+        sim_metadata : SimMetadata
+            Metadata describing the simulation to run (parent restart file,
+            weights, iteration ID, etc.).
+        """
+        self.__logger.info(  # type: ignore[misc]
+            f'Running simulation {sim_metadata.simulation_id} '
+            f'iteration {sim_metadata.iteration_id}',
+        )
+
+        # Execute the simulation and get the raw result dict
+        result_dict = await self.run_simulation(sim_metadata.model_dump())
+
+        # Build the SimResult dataclass from the result
+        updated_metadata = SimMetadata(**result_dict['metadata'])
+
+        # Collect trajectory-derived data arrays
+        contact_maps = result_dict.get('contact_maps', np.array([]))
+        rmsd = result_dict.get('rmsd', np.array([]))
+
+        sim_result = SimResult(
+            data={
+                'contact_maps': np.array(contact_maps),
+                'rmsd': np.array(rmsd),
+            },
+            metadata=updated_metadata,
+        )
+
+        self.__logger.info(  # type: ignore[misc]
+            f'Simulation {sim_metadata.simulation_id} complete, '
+            f'forwarding result to training and inference agents.',
+        )
+
+        # Stream directly to TrainingAgent and InferenceAgent (decentralized pattern)
+        forward_tasks = []
+        if self.train_handle is not None:
+            forward_tasks.append(
+                self.train_handle.receive_simulation_data(sim_result),
+            )
+        if self.inference_handle is not None:
+            forward_tasks.append(
+                self.inference_handle.receive_simulation_data(sim_result),
+            )
+
+        if forward_tasks:
+            await asyncio.gather(*forward_tasks)
 
     @action
     async def run_simulation(
@@ -118,23 +219,28 @@ class SimulationAgent(AcademyAgent):
             # We run this in a thread pool to avoid blocking the event loop
             await asyncio.to_thread(simulation.run, reporters=reporters)
 
-            # Extract progress coordinate (RMSD values) if reporter was used
+            # Extract progress coordinate (RMSD values) and contact maps
+            # from the reporter if one was configured.
             if reporters:
                 pcoord = reporters[0].get_rmsds()
+                contact_maps = reporters[0].get_contact_maps()
             else:
-                # No progress coordinate computed
+                # No progress coordinate / contact maps computed
                 pcoord = []
+                contact_maps = []
 
-            # Get trajectory data
+            # Get trajectory file paths
             trajectory_data = {
                 'restart_file': str(simulation.restart_file),
                 'trajectory_file': str(simulation.trajectory_file),
                 'log_file': str(simulation.log_file),
             }
 
-            # Update metadata with progress coordinate
+            # Update metadata with progress coordinate and contact map auxdata
             sim_metadata.restart_file = simulation.restart_file
-            sim_metadata.pcoord = pcoord.tolist()
+            sim_metadata.pcoord = (
+                pcoord.tolist() if hasattr(pcoord, 'tolist') else list(pcoord)
+            )
             sim_metadata.mark_simulation_end()
 
             self.logger.info(
@@ -145,6 +251,17 @@ class SimulationAgent(AcademyAgent):
             return {
                 'metadata': sim_metadata.model_dump(),
                 'trajectory': trajectory_data,
+                # Data arrays used by the simulate() action to build SimResult
+                'contact_maps': (
+                    contact_maps.tolist()
+                    if hasattr(contact_maps, 'tolist')
+                    else list(contact_maps)
+                ),
+                'rmsd': (
+                    pcoord.tolist()
+                    if hasattr(pcoord, 'tolist')
+                    else list(pcoord)
+                ),
                 'success': True,
             }
 
@@ -155,6 +272,8 @@ class SimulationAgent(AcademyAgent):
             return {
                 'metadata': sim_metadata.model_dump(),
                 'trajectory': {},
+                'contact_maps': [],
+                'rmsd': [],
                 'success': False,
                 'error': str(e),
             }

--- a/deepdrivewe/academy_agents/training.py
+++ b/deepdrivewe/academy_agents/training.py
@@ -1,0 +1,295 @@
+"""Training agent for online CVAE model training on simulation data."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from academy.agent import action
+from academy.agent import loop
+from academy.handle import Handle
+
+from deepdrivewe.api import SimResult
+from deepdrivewe.api import TrainResult
+from deepdrivewe.academy_agents.base import AcademyAgent
+
+if TYPE_CHECKING:
+    from deepdrivewe.academy_agents.inference import InferenceAgent
+
+
+class TrainingAgentConfig:
+    """Configuration for the TrainingAgent.
+
+    Parameters
+    ----------
+    output_dir : Path
+        Directory to store model checkpoints.
+    pretrained_model_path : Path | None
+        Path to a pretrained CVAE model checkpoint to load on startup.
+        If None, the model will be initialized from scratch.
+    train_frequency : int
+        Number of SimResults to accumulate before triggering a training step.
+    cvae_config : ConvolutionalVAEConfig | None
+        Configuration for the CVAE model. If None, default settings are used.
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        pretrained_model_path: Path | None = None,
+        train_frequency: int = 1,
+        cvae_config: object | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.pretrained_model_path = pretrained_model_path
+        self.train_frequency = train_frequency
+        self.cvae_config = cvae_config
+
+
+class TrainingAgent(AcademyAgent):
+    """Agent that trains the CVAE model on incoming simulation data.
+
+    This agent runs on a GPU node and keeps the model warm in memory
+    across iterations. It receives SimResult objects from SimulationAgents
+    via its mailbox, accumulates them in an internal queue, and trains the
+    CVAE when enough data has been collected.
+
+    After each training step, it sends the path to the updated model
+    checkpoint to the InferenceAgent.
+
+    This agent mirrors the TrainingAgent pattern from the minimal_pattern
+    example (https://github.com/braceal/deepdrivewe-academy), extended
+    with real CVAE training logic.
+
+    Attributes
+    ----------
+    config : TrainingAgentConfig
+        Configuration for the training agent.
+    inference_handle : Handle[InferenceAgent]
+        Handle to the inference agent to send model weights to.
+    """
+
+    # Class-level type annotation for the private logger (not serialized)
+    __logger: logging.Logger
+
+    # Internal queue for receiving SimResult objects from simulation agents
+    __queue: asyncio.Queue[SimResult]
+
+    def __init__(
+        self,
+        inference_handle: Handle[InferenceAgent],
+        config: TrainingAgentConfig,
+    ) -> None:
+        """Initialize the training agent.
+
+        Parameters
+        ----------
+        inference_handle : Handle[InferenceAgent]
+            Handle to the inference agent to send updated model weights.
+        config : TrainingAgentConfig
+            Configuration for the training agent.
+        """
+        super().__init__()
+        self.inference_handle = inference_handle
+        self.config = config
+
+    async def agent_on_startup(self) -> None:
+        """Initialize state and load the CVAE model onto GPU.
+
+        This is called by the Academy runtime when the agent starts. All
+        stateful initialization (model loading, queue creation) happens
+        here rather than in __init__ to ensure it runs on the correct
+        worker process (i.e., the GPU node where this agent is placed).
+        """
+        self.__logger = logging.getLogger(self.__class__.__name__)  # type: ignore[misc]
+        self.__queue = asyncio.Queue()
+
+        # Ensure output directory exists
+        self.config.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load the CVAE model (lazy import to avoid requiring torch at
+        # import time on the client / head node)
+        try:
+            from deepdrivewe.ai.cvae import ConvolutionalVAE
+            from deepdrivewe.ai.cvae import ConvolutionalVAEConfig
+
+            cvae_config = (
+                self.config.cvae_config
+                if self.config.cvae_config is not None
+                else ConvolutionalVAEConfig()
+            )
+
+            self.__model = ConvolutionalVAE(  # type: ignore[misc]
+                config=cvae_config,
+                checkpoint_path=self.config.pretrained_model_path,
+            )
+
+            self.__logger.info(
+                'CVAE model loaded successfully'
+                + (
+                    f' from {self.config.pretrained_model_path}'
+                    if self.config.pretrained_model_path
+                    else ' (initialized from scratch)'
+                ),
+            )
+        except ImportError as e:
+            # mdlearn / torch not available — run in CPU-only / mock mode
+            self.__logger.warning(
+                f'Could not import CVAE model dependencies: {e}. '
+                'Running in mock mode (no actual training will occur).',
+            )
+            self.__model = None  # type: ignore[misc]
+
+        self.__logger.info('TrainingAgent started')
+
+    @action
+    async def receive_simulation_data(self, result: SimResult) -> None:
+        """Receive a simulation result and queue it for training.
+
+        This action is called by each SimulationAgent after completing
+        a simulation run. The result is placed onto an internal async
+        queue which is drained by the ``train`` loop.
+
+        Parameters
+        ----------
+        result : SimResult
+            The completed simulation result, including trajectory data
+            (contact maps, RMSD) and metadata.
+        """
+        self.__logger.info(
+            f'Received simulation data for sim '
+            f'{result.metadata.simulation_id} '
+            f'iteration {result.metadata.iteration_id}',
+        )
+        await self.__queue.put(result)
+
+    @loop
+    async def train(self, shutdown: asyncio.Event) -> None:
+        """Drain the simulation queue and train the CVAE model.
+
+        This loop runs continuously in the background. It accumulates
+        ``config.train_frequency`` SimResult objects, then trains the CVAE
+        on the collected contact maps. After training, it sends the path of
+        the new model checkpoint to the InferenceAgent.
+
+        The loop exits gracefully when the ``shutdown`` event is set.
+
+        Parameters
+        ----------
+        shutdown : asyncio.Event
+            Event set by the Academy runtime when the agent should stop.
+        """
+        self.__logger.info('Training loop started')
+
+        while not shutdown.is_set():
+            # Accumulate train_frequency results before training
+            batch: list[SimResult] = []
+
+            for _ in range(self.config.train_frequency):
+                try:
+                    result = await asyncio.wait_for(
+                        self.__queue.get(),
+                        timeout=1.0,
+                    )
+                    batch.append(result)
+                    self.__queue.task_done()
+                except asyncio.TimeoutError:
+                    # Check shutdown and retry
+                    if shutdown.is_set():
+                        break
+                    continue
+
+            if not batch:
+                continue
+
+            self.__logger.info(
+                f'Training on batch of {len(batch)} simulation results',
+            )
+
+            try:
+                checkpoint_path = await asyncio.to_thread(
+                    self._train_on_batch,
+                    batch,
+                )
+
+                self.__logger.info(
+                    f'Training complete. Checkpoint: {checkpoint_path}',
+                )
+
+                # Send updated model weights to the inference agent
+                train_result = TrainResult(
+                    config_path=self.config.output_dir / 'cvae_config.yaml',
+                    checkpoint_path=checkpoint_path,
+                )
+                await self.inference_handle.receive_model_weights(train_result)
+
+            except Exception as e:
+                self._log_error('train', e)
+
+        self.__logger.info('Training loop exited')
+
+    def _train_on_batch(self, batch: list[SimResult]) -> Path:
+        """Train the CVAE model on a batch of simulation results.
+
+        This is a synchronous method run in a thread via asyncio.to_thread
+        so that it does not block the event loop during GPU computation.
+
+        Parameters
+        ----------
+        batch : list[SimResult]
+            Batch of simulation results containing contact maps.
+
+        Returns
+        -------
+        Path
+            Path to the newly saved model checkpoint.
+        """
+        import numpy as np
+
+        # Extract contact maps from the simulation results
+        # Shape: list of (n_frames, n_atoms, n_atoms) arrays
+        all_contact_maps = []
+        all_rmsds = []
+
+        for result in batch:
+            contact_maps = result.data.get('contact_maps')
+            rmsd = result.data.get('rmsd')
+
+            if contact_maps is not None and len(contact_maps) > 0:
+                all_contact_maps.append(contact_maps)
+
+            if rmsd is not None and len(rmsd) > 0:
+                all_rmsds.append(rmsd)
+
+        if not all_contact_maps or self.__model is None:  # type: ignore[misc]
+            # No contact map data or no model — save a placeholder checkpoint
+            self.__logger.warning(
+                'No contact map data available for training or model is None. '
+                'Saving placeholder checkpoint.',
+            )
+            placeholder = self.config.output_dir / 'model_placeholder.pt'
+            placeholder.touch()
+            return placeholder
+
+        # Stack all contact maps: (total_frames, n_atoms, n_atoms)
+        x = np.concatenate(all_contact_maps, axis=0)
+        scalars = {}
+
+        if all_rmsds:
+            scalars['rmsd'] = np.concatenate(all_rmsds, axis=0)
+
+        # Determine model output directory for this training step
+        iteration = batch[0].metadata.iteration_id
+        model_dir = self.config.output_dir / f'cvae_iter_{iteration:06d}'
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        # Fit the CVAE and get the latest checkpoint path
+        checkpoint_path = self.__model.fit(  # type: ignore[misc]
+            x=x,
+            model_dir=model_dir,
+            scalars=scalars if scalars else None,
+        )
+
+        return checkpoint_path

--- a/examples/openmm_ntl9_hk_academy/main_academy.py
+++ b/examples/openmm_ntl9_hk_academy/main_academy.py
@@ -1,7 +1,35 @@
-"""Academy-based NTL9 protein folding example using OpenMM and Huber-Kim resampling.
+"""Academy-based NTL9 protein folding workflow using OpenMM and Huber-Kim resampling.
 
-This script demonstrates the complete Academy agents workflow for weighted ensemble
-simulations, replacing the Colmena-based implementation with Academy agents.
+This script implements the decentralized multi-agent architecture described in
+https://github.com/braceal/deepdrivewe-academy/tree/main/examples/minimal_pattern,
+extended with real OpenMM simulations, CVAE training, and weighted ensemble resampling.
+
+Agent Topology
+--------------
+::
+
+    main()
+      ├── register + launch ──> SimulationAgent × N  (one per trajectory)
+      ├── register + launch ──> TrainingAgent         (GPU node, CVAE training)
+      └── register + launch ──> InferenceAgent        (GPU node, WE resampling)
+
+    SimulationAgent ──SimResult──> TrainingAgent.receive_simulation_data()
+    SimulationAgent ──SimResult──> InferenceAgent.receive_simulation_data()
+    TrainingAgent   ──TrainResult──> InferenceAgent.receive_model_weights()
+    InferenceAgent  ──SimMetadata──> SimulationAgent.simulate()   (next iter)
+    main()          ──await manager.wait((inference_handle,))──>  blocks until done
+
+Circular dependencies (SimulationAgent ↔ InferenceAgent) are resolved by
+using the register → get_handle → launch pattern from the Academy framework:
+mailboxes are created for all agents first, handles are obtained before
+instantiation, and agents are launched last with all handles already in hand.
+
+Usage
+-----
+::
+
+    python examples/openmm_ntl9_hk_academy/main_academy.py -c config_minimal.yaml
+
 """
 
 from __future__ import annotations
@@ -22,14 +50,14 @@ from deepdrivewe import BasisStates
 from deepdrivewe import EnsembleCheckpointer
 from deepdrivewe import TargetState
 from deepdrivewe import WeightedEnsemble
-from deepdrivewe.academy_agents.analysis import AnalysisPoolAgent
-from deepdrivewe.academy_agents.config import AcademyWorkflowConfig
-from deepdrivewe.academy_agents.config import AnalysisPoolConfig
+from deepdrivewe.academy_agents.config import InferenceAgentConfig
 from deepdrivewe.academy_agents.config import SimulationPoolConfig
-from deepdrivewe.academy_agents.ensemble import EnsembleManagerAgent
-from deepdrivewe.academy_agents.orchestrator import OrchestratorAgent
+from deepdrivewe.academy_agents.config import TrainingAgentConfig
+from deepdrivewe.academy_agents.inference import InferenceAgent
+from deepdrivewe.academy_agents.inference import InferenceAgentConfig as _InfCfg
 from deepdrivewe.academy_agents.simulation import SimulationAgent
-from deepdrivewe.academy_agents.simulation import SimulationPoolAgent
+from deepdrivewe.academy_agents.training import TrainingAgent
+from deepdrivewe.academy_agents.training import TrainingAgentConfig as _TrnCfg
 from deepdrivewe.binners import RectilinearBinner
 from deepdrivewe.examples.openmm_ntl9_hk.inference import InferenceConfig
 from deepdrivewe.examples.openmm_ntl9_hk.main import RMSDBasisStateInitializer
@@ -43,55 +71,60 @@ class ExperimentSettings(BaseModel):
 
     output_dir: Path = Field(description='Output directory for results')
     num_iterations: int = Field(description='Number of WE iterations to run')
+    num_simulations: int = Field(
+        default=4,
+        description='Number of parallel SimulationAgents to launch.',
+    )
     max_retries: int = Field(default=3, description='Max retries for failed sims')
     basis_states: BasisStates
     basis_state_initializer: RMSDBasisStateInitializer
     simulation_config: SimulationConfig
     inference_config: InferenceConfig
     target_states: list[TargetState]
-    academy_config: dict = Field(
-        default_factory=lambda: {'num_workers': 2, 'exchange_type': 'local'},
-    )
-    analysis_config: dict | None = Field(
+    # Optional override dicts for the new decentralized agents
+    training_agent_config: dict | None = Field(
         default=None,
-        description='Optional analysis configuration for Phase 3',
+        description='Extra TrainingAgentConfig fields (dict). '
+        'None uses defaults.',
+    )
+    inference_agent_config: dict | None = Field(
+        default=None,
+        description='Extra InferenceAgentConfig fields (dict). '
+        'None uses defaults.',
     )
 
 
-async def run_academy_workflow(cfg: ExperimentSettings) -> None:
-    """Run the Academy-based weighted ensemble workflow."""
-    logging.info('Starting Academy-based NTL9 folding workflow')
-    
-    # Create output directory
+async def run_workflow(cfg: ExperimentSettings) -> None:
+    """Run the decentralized Academy workflow.
+
+    This implements the register → get_handle → launch pattern described
+    in the minimal_pattern example, extended with real WE simulation logic.
+    """
+    logging.info('Starting decentralized Academy NTL9 folding workflow')
+
+    # ------------------------------------------------------------------
+    # Setup: output directory, checkpointing, ensemble state
+    # ------------------------------------------------------------------
     cfg.output_dir.mkdir(parents=True, exist_ok=True)
-    
-    # Create the checkpoint manager
     checkpointer = EnsembleCheckpointer(output_dir=cfg.output_dir)
-    
-    # Check if a checkpoint exists
     checkpoint = checkpointer.latest_checkpoint()
-    
+
     if checkpoint is None:
-        # Initialize the weighted ensemble
         ensemble = WeightedEnsemble(
             basis_states=cfg.basis_states,
             target_states=cfg.target_states,
         )
-        
-        # Initialize the simulations with the basis states
         ensemble.initialize_basis_states(cfg.basis_state_initializer)
         logging.info('Initialized new weighted ensemble')
     else:
-        # Load the ensemble from a checkpoint if it exists
         ensemble = checkpointer.load(checkpoint)
-        logging.info(f'Loaded ensemble from checkpoint {checkpoint}')
-    
-    # Print the input states
-    logging.info(f'Basis states: {ensemble.basis_states}')
-    logging.info(f'Target states: {ensemble.target_states}')
+        logging.info(f'Loaded ensemble from checkpoint: {checkpoint}')
+
     logging.info(f'Initial ensemble size: {len(ensemble.next_sims)}')
-    
-    # Create binner, resampler, and recycler
+
+    # ------------------------------------------------------------------
+    # WE algorithm components (binner / resampler / recycler)
+    # ------------------------------------------------------------------
     binner = RectilinearBinner(
         bins=[0.0, 1.00]
         + [1.10 + 0.1 * i for i in range(35)]
@@ -100,21 +133,23 @@ async def run_academy_workflow(cfg: ExperimentSettings) -> None:
         + [float('inf')],
         bin_target_counts=cfg.inference_config.sims_per_bin,
     )
-    
+
     resampler = HuberKimResampler(
         sims_per_bin=cfg.inference_config.sims_per_bin,
         max_allowed_weight=cfg.inference_config.max_allowed_weight,
         min_allowed_weight=cfg.inference_config.min_allowed_weight,
     )
-    
+
     recycler = LowRecycler(
         basis_states=ensemble.basis_states,
         target_threshold=cfg.target_states[0].pcoord[0],
     )
-    
-    # Create simulation pool configuration
+
+    # ------------------------------------------------------------------
+    # Per-agent configuration objects
+    # ------------------------------------------------------------------
     sim_pool_config = SimulationPoolConfig(
-        num_workers=cfg.academy_config['num_workers'],
+        num_workers=cfg.num_simulations,
         max_retries=cfg.max_retries,
         retry_delay=1.0,
         output_dir=cfg.output_dir / 'simulations',
@@ -125,115 +160,165 @@ async def run_academy_workflow(cfg: ExperimentSettings) -> None:
         openmm_selection=cfg.simulation_config.openmm_selection,
     )
 
-    # Create Academy workflow configuration
-    workflow_config = AcademyWorkflowConfig(
-        num_iterations=cfg.num_iterations,
-        checkpoint_interval=1,
-        output_dir=cfg.output_dir,
-        simulation_pool_config=sim_pool_config,
+    # Build TrainingAgentConfig (use simple dataclass from training module)
+    raw_train_cfg = cfg.training_agent_config or {}
+    train_agent_cfg = _TrnCfg(
+        output_dir=cfg.output_dir / 'training',
+        **raw_train_cfg,
     )
-    
-    logging.info('Launching Academy agents...')
-    
-    # Launch Academy agents
+
+    # Build InferenceAgentConfig (use simple dataclass from inference module)
+    raw_inf_cfg = cfg.inference_agent_config or {}
+    inf_agent_cfg = _InfCfg(
+        output_dir=cfg.output_dir / 'inference',
+        **raw_inf_cfg,
+    )
+
+    # ------------------------------------------------------------------
+    # Academy manager + decentralized agent launch
+    # ------------------------------------------------------------------
+    logging.info('Launching Academy agents (decentralized topology)...')
+
     async with await Manager.from_exchange_factory(
+        # Use LocalExchangeFactory for local testing; swap to
+        # HybridExchangeFactory(redis_url=...) for HPC deployments.
         factory=LocalExchangeFactory(),
         executors=ThreadPoolExecutor(),
     ) as manager:
-        # Launch simulation worker agents
-        workers = []
-        for i in range(sim_pool_config.num_workers):
-            worker = await manager.launch(SimulationAgent, args=(sim_pool_config,))
-            workers.append(worker)
-            logging.info(f'Launched SimulationAgent worker {i}')
-        
-        # Launch simulation pool agent
-        pool_agent = await manager.launch(
-            SimulationPoolAgent,
-            args=(sim_pool_config, workers),
+
+        # ------------------------------------------------------------------
+        # Phase 1: Register all agents (creates mailboxes, no instantiation)
+        #
+        # This is required to resolve the circular dependency:
+        #   SimulationAgent ──> InferenceAgent ──> SimulationAgent
+        #
+        # Registering creates each agent's mailbox and returns a registration
+        # object from which a Handle can be obtained — even before the agent
+        # is running. This is the key insight from the minimal_pattern example.
+        # ------------------------------------------------------------------
+        reg_inference = await manager.register_agent(InferenceAgent)
+        reg_training = await manager.register_agent(TrainingAgent)
+        reg_simulations = await asyncio.gather(
+            *[
+                manager.register_agent(SimulationAgent)
+                for _ in range(cfg.num_simulations)
+            ],
         )
-        logging.info('Launched SimulationPoolAgent')
 
-        # Launch ensemble manager agent
-        ensemble_agent = await manager.launch(
-            EnsembleManagerAgent,
-            args=(ensemble, binner, resampler, recycler),
+        logging.info(
+            f'Registered {len(reg_simulations)} SimulationAgent(s), '
+            '1 TrainingAgent, 1 InferenceAgent',
         )
-        logging.info('Launched EnsembleManagerAgent')
 
-        # Launch analysis pool agent if analysis is enabled
-        analysis_agent = None
-        if cfg.analysis_config is not None:
-            analysis_pool_config = AnalysisPoolConfig(
-                output_dir=cfg.output_dir / 'analysis',
-                enabled_analyzers=cfg.analysis_config.get('enabled_analyzers', []),
-                analyzer_configs=cfg.analysis_config.get('analyzer_configs', {}),
-            )
-            analysis_agent = await manager.launch(
-                AnalysisPoolAgent,
-                args=(
-                    analysis_pool_config.output_dir,
-                    analysis_pool_config.enabled_analyzers,
-                    analysis_pool_config.analyzer_configs,
-                ),
-            )
-            logging.info(f'Launched AnalysisPoolAgent with analyzers: {analysis_pool_config.enabled_analyzers}')
+        # ------------------------------------------------------------------
+        # Phase 2: Get handles BEFORE launching
+        #
+        # Handles are mailbox references — they can be passed to agent
+        # constructors even before the target agent has been instantiated.
+        # ------------------------------------------------------------------
+        inference_handle = manager.get_handle(reg_inference)
+        training_handle = manager.get_handle(reg_training)
+        simulation_handles = [
+            manager.get_handle(reg) for reg in reg_simulations
+        ]
 
-        # Launch orchestrator agent (pass handles, not agents)
-        orchestrator = await manager.launch(
-            OrchestratorAgent,
-            args=(workflow_config, pool_agent, ensemble_agent, checkpointer, analysis_agent),
+        # ------------------------------------------------------------------
+        # Phase 3: Launch agents with all handles already resolved
+        #
+        # Launch order:
+        #   1. InferenceAgent — owns the iteration loop; loads pretrained
+        #      model on startup; must be ready before simulations start.
+        #   2. TrainingAgent  — loads CVAE model on startup.
+        #   3. SimulationAgents — dispatched in parallel via asyncio.gather.
+        # ------------------------------------------------------------------
+
+        # 1. InferenceAgent
+        inference_handle = await manager.launch(
+            InferenceAgent,
+            registration=reg_inference,
+            args=(
+                cfg.num_simulations,    # num_simulations (batch size)
+                cfg.num_iterations,     # max_iterations
+                simulation_handles,     # list[Handle[SimulationAgent]]
+                inf_agent_cfg,          # InferenceAgentConfig
+                binner,                 # Binner
+                resampler,              # Resampler
+                recycler,               # Recycler
+                ensemble,               # WeightedEnsemble (initial state)
+                checkpointer,           # EnsembleCheckpointer
+            ),
         )
-        logging.info('Launched OrchestratorAgent')
+        logging.info('Launched InferenceAgent')
 
-        # Start the workflow
-        logging.info('Starting weighted ensemble workflow...')
-        await orchestrator.start_workflow()
+        # 2. TrainingAgent
+        training_handle = await manager.launch(
+            TrainingAgent,
+            registration=reg_training,
+            args=(
+                inference_handle,       # Handle[InferenceAgent]
+                train_agent_cfg,        # TrainingAgentConfig
+            ),
+        )
+        logging.info('Launched TrainingAgent')
 
-        # Run iterations
-        logging.info('Running weighted ensemble iterations...')
-        for iteration in range(cfg.num_iterations):
-            logging.info(f'Starting iteration {iteration + 1}/{cfg.num_iterations}')
+        # 3. SimulationAgents (parallel launch)
+        simulation_agents = await asyncio.gather(
+            *[
+                manager.launch(
+                    SimulationAgent,
+                    registration=reg,
+                    args=(
+                        sim_pool_config,    # SimulationPoolConfig
+                        training_handle,    # Handle[TrainingAgent]
+                        inference_handle,   # Handle[InferenceAgent]
+                    ),
+                )
+                for reg in reg_simulations
+            ],
+        )
+        logging.info(f'Launched {len(simulation_agents)} SimulationAgent(s)')
 
-            # Advance iteration
-            success = await orchestrator.advance_iteration()
+        # ------------------------------------------------------------------
+        # Kick off iteration 1
+        #
+        # The initial SimMetadata objects come from the ensemble's next_sims
+        # (either basis states for a fresh run, or the last checkpoint's
+        # next_sims when resuming). We dispatch them concurrently.
+        # ------------------------------------------------------------------
+        initial_sims = ensemble.next_sims
 
-            if not success:
-                logging.info('Workflow completed early')
-                break
+        logging.info(
+            f'Dispatching {len(initial_sims)} simulation(s) '
+            f'to kick off iteration {ensemble.iteration}...',
+        )
+        await asyncio.gather(
+            *[
+                # Round-robin across agents if more sims than agents
+                simulation_agents[idx % len(simulation_agents)].simulate(sim)
+                for idx, sim in enumerate(initial_sims)
+            ],
+        )
 
-            # Get status
-            status = await orchestrator.get_status()
-            logging.info(
-                f"Iteration {status['current_iteration']}/{status['total_iterations']} - "
-                f"Ensemble: {status['ensemble_state']['num_current_sims']} current sims, "
-                f"{status['ensemble_state']['num_next_sims']} next sims"
-            )
+        # ------------------------------------------------------------------
+        # Block until the InferenceAgent signals completion
+        #
+        # The InferenceAgent's @loop calls shutdown.set() after
+        # max_iterations. manager.wait() returns when the agent exits,
+        # and the async context manager cascades shutdown to all other agents.
+        # ------------------------------------------------------------------
+        logging.info(
+            'Simulations dispatched. '
+            'Waiting for InferenceAgent to signal completion...',
+        )
+        await manager.wait((inference_handle,))
 
-        # Get final status
-        final_status = await orchestrator.get_status()
-        logging.info(f'Workflow completed!')
-        logging.info(f'Final status: {final_status}')
-
-        # Shutdown agents
-        logging.info('Shutting down agents...')
-        await manager.shutdown(orchestrator, blocking=True)
-        await manager.shutdown(ensemble_agent, blocking=True)
-        if analysis_agent is not None:
-            await manager.shutdown(analysis_agent, blocking=True)
-        await manager.shutdown(pool_agent, blocking=True)
-        for worker in workers:
-            await manager.shutdown(worker, blocking=True)
-
-        logging.info('All agents shut down successfully')
-
-    logging.info('Academy workflow completed!')
+    logging.info('All agents shut down. Workflow complete.')
 
 
 def main() -> None:
     """Main entry point."""
     parser = ArgumentParser(
-        description='Run NTL9 folding with Academy agents'
+        description='Run NTL9 folding with decentralized Academy agents',
     )
     parser.add_argument(
         '-c',
@@ -243,14 +328,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Load configuration
     cfg = ExperimentSettings.from_yaml(args.config)
 
-    # Save configuration to output directory
     cfg.output_dir.mkdir(parents=True, exist_ok=True)
     cfg.dump_yaml(cfg.output_dir / 'params.yaml')
 
-    # Set up logging
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         level=logging.INFO,
@@ -260,25 +342,22 @@ def main() -> None:
         ],
     )
 
-    logging.info('='*80)
-    logging.info('Academy-based NTL9 Protein Folding Workflow')
-    logging.info('='*80)
-    logging.info(f'Configuration: {args.config}')
+    logging.info('=' * 80)
+    logging.info('Academy NTL9 Folding Workflow (decentralized agent topology)')
+    logging.info('=' * 80)
+    logging.info(f'Configuration:    {args.config}')
     logging.info(f'Output directory: {cfg.output_dir}')
-    logging.info(f'Number of iterations: {cfg.num_iterations}')
-    logging.info(f'Number of workers: {cfg.academy_config["num_workers"]}')
-    logging.info('='*80)
+    logging.info(f'Iterations:       {cfg.num_iterations}')
+    logging.info(f'Simulations:      {cfg.num_simulations}')
+    logging.info('=' * 80)
 
-    # Run the async workflow
     try:
-        asyncio.run(run_academy_workflow(cfg))
+        asyncio.run(run_workflow(cfg))
         logging.info('Workflow completed successfully!')
     except Exception as e:
-        logging.error(f'Workflow failed with error: {e}', exc_info=True)
+        logging.error(f'Workflow failed: {e}', exc_info=True)
         sys.exit(1)
 
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
## Summary

- **Add `TrainingAgent`** (`deepdrivewe/academy_agents/training.py`): stateful GPU actor that streams `SimResult` objects into an `asyncio.Queue`, trains the CVAE model on contact maps, and sends a `TrainResult` (checkpoint path) to the `InferenceAgent`. Model stays warm in GPU memory via `agent_on_startup()` — no `parsl_object_registry` workaround needed.
- **Add `InferenceAgent`** (`deepdrivewe/academy_agents/inference.py`): stateful GPU actor that buffers N `SimResult` objects per iteration, runs CVAE latent projection, applies WE resampling (binner / recycler / resampler), saves checkpoint, and dispatches next `SimMetadata` directly to each `SimulationAgent`. Owns the shutdown signal at `max_iterations`.
- **Update `SimulationAgent`**: add `simulate(sim_metadata)` action matching `minimal_pattern` API; streams `SimResult` directly to both agents via `asyncio.gather`. Accepts optional `train_handle` and `inference_handle` constructor args.
- **Update `config.py`**: add `TrainingAgentConfig` and `InferenceAgentConfig` Pydantic models; extend `AcademyWorkflowConfig` with `num_simulations` and both new config fields.
- **Rewrite `main_academy.py`**: uses `register → get_handle → launch` pattern from [minimal_pattern](https://github.com/braceal/deepdrivewe-academy/tree/main/examples/minimal_pattern), resolving the `SimulationAgent ↔ InferenceAgent` circular dependency. Blocks with `manager.wait((inference_handle,))`.

## Architecture
SimulationAgent ──SimResult──> TrainingAgent.receive_simulation_data()
SimulationAgent ──SimResult──> InferenceAgent.receive_simulation_data()
TrainingAgent ──TrainResult──> InferenceAgent.receive_model_weights()
InferenceAgent ──SimMetadata──> SimulationAgent.simulate() (next iter)
main() ──await manager.wait((inference_handle,))──> blocks until done


## Test plan

- [ ] Import smoke test: `python -c "from deepdrivewe.academy_agents.training import TrainingAgent; from deepdrivewe.academy_agents.inference import InferenceAgent"`
- [ ] `pytest tests/academy_agents/` — verify no regressions
- [ ] Local 2-iteration smoke test with `LocalExchangeFactory` + mock data
- [ ] End-to-end on GPU workstation with real OpenMM simulations
- [ ] HPC validation on Vista@TACC with `VistaConfig` and `HybridExchangeClient`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
