### PR TITLE
MultiRectilinearBinner bin ID fix

### DIFF
--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -101,7 +101,7 @@ class MultiRectilinearBinner(Binner):
         bin_ids = np.zeros(len(pcoords), dtype=int)
         for idx, ibid in enumerate(bid.T):
             for idim in range(len(nbins_per_dim) - 1):
-                bin_ids[idx] += (ibid[idim] - 1) * nbins_per_dim[idim + 1]
+                bin_ids[idx] += (ibid[idim] - 1) * np.prod(nbins_per_dim[idim + 1:])
             bin_ids[idx] += ibid[-1] - 1
 
         # Check that the number of bin indices is the same as the

--- a/deepdrivewe/binners/multirectilinear.py
+++ b/deepdrivewe/binners/multirectilinear.py
@@ -101,7 +101,7 @@ class MultiRectilinearBinner(Binner):
         bin_ids = np.zeros(len(pcoords), dtype=int)
         for idx, ibid in enumerate(bid.T):
             for idim in range(len(nbins_per_dim) - 1):
-                bin_ids[idx] += (ibid[idim] - 1) * nbins_per_dim[idim]
+                bin_ids[idx] += (ibid[idim] - 1) * nbins_per_dim[idim + 1]
             bin_ids[idx] += ibid[-1] - 1
 
         # Check that the number of bin indices is the same as the

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -57,7 +57,8 @@ class TestRectilinearBinner:
         boundaries = [(0, 1, 2), (0, 1, 2, 3, 4, 5), (0, 1, 2)]
         coords = list(product([0.5, 1.5], [0.5, 1.5, 2.5, 3.5, 4.5], [0.5, 1.5]))  # One point per bin, in row-major order
         coords += [(2.5, 4.5, 1.5), (1.5, 5.5, 1.5)]  # Two points that are located outside the bin boundaries
-
+        coords = np.asarray(coords)
+        
         assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
 
         with pytest.warns(UserWarning):

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -49,4 +49,38 @@ class TestRectilinearBinner:
         assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
 
         with pytest.warns(UserWarning):
+            # first 6 points are in bins [0, 5]. The last point locate outside the bounds but will be clipped to bin 5
             assert (assigner.assign_bins(coords) == [0, 1, 2, 3, 4, 5, 5]).all()
+
+    def test3dAssign(self) -> None: 
+        boundaries = [(0, 1, 2), (0, 1, 2, 3, 4, 5), (0, 1, 2)]
+        coords = np.array([(0.5, 0.5, 0.5),
+                           (0.5, 0.5, 1.5),
+                           (0.5, 1.5, 0.5),
+                           (0.5, 1.5, 1.5),
+                           (0.5, 2.5, 0.5),
+                           (0.5, 2.5, 1.5),
+                           (0.5, 3.5, 0.5),
+                           (0.5, 3.5, 1.5),
+                           (0.5, 4.5, 0.5),
+                           (0.5, 4.5, 1.5),
+                           (1.5, 0.5, 0.5),
+                           (1.5, 0.5, 1.5),
+                           (1.5, 1.5, 0.5),
+                           (1.5, 1.5, 1.5),
+                           (1.5, 2.5, 0.5),
+                           (1.5, 2.5, 1.5),
+                           (1.5, 3.5, 0.5),
+                           (1.5, 3.5, 1.5),
+                           (1.5, 4.5, 0.5),
+                           (1.5, 4.5, 1.5),
+                           (2.5, 4.5, 1.5),
+                           (1.5, 5.5, 1.5),])
+
+        assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
+
+        with pytest.warns(UserWarning):
+            # first 20 points are in bins [0, 19]. The last two locate outside the bounds but will be clipped to bin 19
+            assert (assigner.assign_bins(coords) == list(range(20)) + [19, 19]).all()
+
+

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -41,3 +41,12 @@ class TestRectilinearBinner:
 
         with pytest.warns(UserWarning):
             assert (assigner.assign_bins(coords) == [0, 0, 5, 10, 10, 15, 7, 8]).all()
+
+    def test2dAssign_v2(self) -> None:
+        boundaries = [(0, 1, 2, 3), (0, 1, 2)]
+        coords = np.array([(0.5, 0.5), (0.5, 1.5), (1.5, 0.5), (1.5, 1.5), (2.5, 0.5), (2.5, 1.5), (3.5, 1.5)])
+
+        assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
+
+        with pytest.warns(UserWarning):
+            assert (assigner.assign_bins(coords) == [0, 1, 2, 3, 4, 5, 5]).all()

--- a/tests/binner_test.py
+++ b/tests/binner_test.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from itertools import product
 
 import numpy as np
 
@@ -54,28 +55,8 @@ class TestRectilinearBinner:
 
     def test3dAssign(self) -> None: 
         boundaries = [(0, 1, 2), (0, 1, 2, 3, 4, 5), (0, 1, 2)]
-        coords = np.array([(0.5, 0.5, 0.5),
-                           (0.5, 0.5, 1.5),
-                           (0.5, 1.5, 0.5),
-                           (0.5, 1.5, 1.5),
-                           (0.5, 2.5, 0.5),
-                           (0.5, 2.5, 1.5),
-                           (0.5, 3.5, 0.5),
-                           (0.5, 3.5, 1.5),
-                           (0.5, 4.5, 0.5),
-                           (0.5, 4.5, 1.5),
-                           (1.5, 0.5, 0.5),
-                           (1.5, 0.5, 1.5),
-                           (1.5, 1.5, 0.5),
-                           (1.5, 1.5, 1.5),
-                           (1.5, 2.5, 0.5),
-                           (1.5, 2.5, 1.5),
-                           (1.5, 3.5, 0.5),
-                           (1.5, 3.5, 1.5),
-                           (1.5, 4.5, 0.5),
-                           (1.5, 4.5, 1.5),
-                           (2.5, 4.5, 1.5),
-                           (1.5, 5.5, 1.5),])
+        coords = list(product([0.5, 1.5], [0.5, 1.5, 2.5, 3.5, 4.5], [0.5, 1.5]))  # One point per bin, in row-major order
+        coords += [(2.5, 4.5, 1.5), (1.5, 5.5, 1.5)]  # Two points that are located outside the bin boundaries
 
         assigner = MultiRectilinearBinner(boundaries, bin_target_counts=3, target_state_inds=[None])
 


### PR DESCRIPTION
There is a bug in the bin id assignment where we could end up with wrong bin ids. This PR fixes it and adds two extra testd to catch the hidden error. The previous test had symmetric binning, which does not encounter the error.

In the bugged version, only one of three conditions will give the wrong binning. The three conditions are:
Given a progress coordinate of N dimensions...
1. If the number of bins in the dimension n > the product of the number of bins in dimension n+1 onwards, then there shouldn't be any problems with bin assignments, though the bin ID of the second dimension onwards will be larger than expected but no cross-contamination will occur between bins.
2. If the number of bins in the dimension n = the product of the number of bins in dimension n+1 onwards then the bin IDs are exact (and correct).
3.  If nbins of dimension n < the product of the number of bins in dimension n+1 onwards, then it is possible some points are assigned the same bin ID as points that should be in a different bin. 

Not sure if vista-stream is the right branch to merge into nowadays, but here it is.