### PR TITLE
Use default_factory for WeightedEnsemble.metadata

### DIFF
--- a/deepdrivewe/api.py
+++ b/deepdrivewe/api.py
@@ -494,7 +494,7 @@ class WeightedEnsemble(BaseModel):
         description='The target states for the weighted ensemble.',
     )
     metadata: IterationMetadata = Field(
-        default=IterationMetadata,
+        default_factory=IterationMetadata,
         description='The metadata for the current iteration.',
     )
     cur_sims: list[SimMetadata] = Field(
@@ -527,7 +527,7 @@ class WeightedEnsemble(BaseModel):
 
     @property
     def iteration(self) -> int:
-        """Return the current iteration of the weighted ensemble."""
+        """The current iteration of the weighted ensemble (1-indexed)."""
         return self.metadata.iteration_id
 
     def advance_iteration(


### PR DESCRIPTION
`WeightedEnsemble.metadata` was declared as:

```python
metadata: IterationMetadata = Field(
    default=IterationMetadata,
    ...
)
```

`default=` assigns the *class object* as the default value rather than constructing an instance, so any `WeightedEnsemble` created without an explicit `metadata` argument carries `IterationMetadata` the class. `self.metadata.iteration_id` then reads an attribute off the class instead of a real iteration id, and the `iteration` property returns something that is not an `int`.

Switched to `default_factory=IterationMetadata`, matching how `cur_sims` and `next_sims` are already declared in the same model.

Also tightened the `iteration` docstring to note the value is 1-indexed.

Extracted from #40 so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)