### PR TITLE
Fix inverted use_stale_model gating in DDWEStreamThinker

### DIFF
--- a/deepdrivewe/workflows/ddwe.py
+++ b/deepdrivewe/workflows/ddwe.py
@@ -314,21 +314,27 @@ class DDWEStreamThinker(BaseThinker):
         # If we have all the simulation results, submit the inference task
         # using the previous iteration's model
         if len(self.sim_output) == len(self.ensemble.next_sims):
-            # We need to wait for the streaming train task to finish
-            if not self.use_stale_model:
+            # We need to wait for the first streaming train task to finish
+            if self.use_stale_model and self.train_output is None:
                 # Wait for the streaming train task to finish
-                self.logger.info('Waiting for streaming train task to finish')
+                self.logger.info(
+                    'Waiting for first streaming train task to finish',
+                )
                 while self.train_output is None:
                     time.sleep(10)
 
-            elif self.use_stale_model:
-                self.logger.info('Waiting for streaming train task to finish')
+            # We need to wait for the next streaming train task to finish
+            # to get a fresh model
+            elif not self.use_stale_model:
+                self.logger.info(
+                    'Waiting for next streaming train task to finish',
+                )
                 while self.train_iteration < self.ensemble.iteration:
                     time.sleep(10)
                 # This should hold (see train_stream_processor)
                 assert self.train_output is not None
 
-            # If it's okay to use the stale model, submit the inference task
+            # Submit the inference task using either a stale or fresh model
             self.submit_task('inference', self.sim_output, self.train_output)
 
     @agent()


### PR DESCRIPTION
The two branches guarding inference submission in `DDWEStreamThinker.process_simulation_result` were swapped relative to what `use_stale_model` means:

```python
if not self.use_stale_model:
    while self.train_output is None:      # only waits for *a* model
        time.sleep(10)
elif self.use_stale_model:
    while self.train_iteration < self.ensemble.iteration:   # waits for a *fresh* model
        time.sleep(10)
```

So `use_stale_model=False` — the strict setting — merely waited for `train_output` to become non-`None` and would then submit inference against an arbitrarily old model. `use_stale_model=True` — the permissive setting — took the strict path and blocked until `train_iteration` caught up with the current ensemble iteration, serializing inference behind training on every iteration.

The branches are now swapped so the flag means what it says:

- `use_stale_model=True` blocks only until the first model exists, then reuses whatever is current.
- `use_stale_model=False` blocks until the current iteration's model is ready.

Log messages are updated to distinguish the two waits ("first" vs "next" streaming train task), which previously printed identical text from both branches.

Extracted from #40 so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)