### PR TITLE
Handle null failure_info in print_errors

### DIFF
--- a/deepdrivewe/cli.py
+++ b/deepdrivewe/cli.py
@@ -43,10 +43,14 @@ def print_errors(
 
         # Parse each line as JSON
         for line in file_text.splitlines():
+            # Parse the line as JSON
             data = json.loads(line)
-            if 'failure_info' in data and 'traceback' in data['failure_info']:
+            # Get the failure info
+            failure_info = data.get('failure_info', None)
+            # Print the method and traceback if it exists
+            if failure_info is not None and 'traceback' in failure_info:
                 console.print(
-                    f"[bold blue]Method:[/bold blue] {data['method']}",
+                    f'[bold blue]Method:[/bold blue] {data["method"]}',
                 )
                 console.print(data['failure_info']['traceback'], style='red')
 


### PR DESCRIPTION
`print_errors` walked result records with:

```python
if 'failure_info' in data and 'traceback' in data['failure_info']:
```

Records can carry an explicit `null` `failure_info` rather than omitting the key. The membership test treats that as present, and the following lookup runs `in` against `None`, raising `TypeError`. The command died partway through the run directory instead of reporting the failures it had already found.

Now reads the field with `.get` and checks it is not `None` before indexing. Also adds comments and normalizes the f-string quoting to match the rest of the file.

Extracted from #40 so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)