### PR TITLE
Fit streaming retrains on the current window of stream items

### DIFF
--- a/deepdrivewe/examples/openmm_ntl9_ddwe/train.py
+++ b/deepdrivewe/examples/openmm_ntl9_ddwe/train.py
@@ -122,8 +122,6 @@ def run_stream_train(
     stream_producer = stream_config.get_producer(topic=TRAIN_TOPIC)
 
     # TODO: Decide how much data we want to keep in the re-train history.
-    contact_map_history = []
-    pcoord_history = []
 
     # Loop indefinitely until we get a stop iteration from the stream consumer
     for idx in itertools.count():
@@ -152,23 +150,17 @@ def run_stream_train(
             break
 
         # Extract the contact maps and rmsd from each simulation
-        contact_maps = np.concatenate([x['contact_maps'] for x in items])
-        pcoords = np.concatenate([x['pcoords'] for x in items])
-        pcoords = pcoords.flatten()
-
-        # TODO: It might be necessary to put these into a numpy array
-        # Concatenate the new data with the history
-        contact_map_history.extend(contact_maps)
-        pcoord_history.extend(pcoords)
+        cmaps = np.array([x['contact_maps'] for x in items], dtype=object)
+        pcoords = np.array([x['pcoords'] for x in items]).flatten()
 
         # Make a new model directory for this iteration
         model_dir = output_dir / f'model_{idx:06d}'
 
         # Fit the model
         checkpoint_path = model.fit(
-            x=contact_map_history,
+            x=cmaps,
             model_dir=model_dir,
-            scalars={'pcoord': pcoord_history},
+            scalars={'pcoord': pcoords},
         )
 
         # Construct the train result


### PR DESCRIPTION
Two problems in `run_stream_train`'s handling of re-train data.

**Contact maps were flattened across frames.** Each streamed item carries a single frame's sparse contact map — `np.concatenate([row, col])`, so a variable-length 1-D array whose length depends on the number of contacts in that frame. The batch was combined with:

```python
contact_maps = np.concatenate([x['contact_maps'] for x in items])
```

which concatenates every frame in the batch into one flat array, destroying frame boundaries before the data reaches `model.fit`. Replaced with an object array holding one entry per frame, matching the ragged layout `ContactMapCollector` produces elsewhere:

```python
cmaps = np.array([x['contact_maps'] for x in items], dtype=object)
```

**History grew without bound.** Each batch was appended to `contact_map_history` / `pcoord_history`, which were never trimmed. Memory climbed for the life of the run, and every retrain re-consumed all data seen so far, so successive retrains got progressively slower.

Each retrain now fits on the current window of stream items only. How much history to retain is still an open question — the existing `TODO` is left in place.

Extracted from #40 so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)